### PR TITLE
Make call to `printf()` safer

### DIFF
--- a/faux-eco-static.c
+++ b/faux-eco-static.c
@@ -8,7 +8,7 @@ const char text[] = {
 
 
 int main(const int argc, char const *argv[]) {
-	printf("%s", text);
+	printf("%.*s", (int) (sizeof(text) / sizeof(text[0])), text);
 
 	return EXIT_SUCCESS;
 }

--- a/faux-eco.c
+++ b/faux-eco.c
@@ -8,11 +8,11 @@
 int main(const int argc, char const *argv[]) {
 	if (argc < 2) {
 		printf("Error: data file not provided as command line argument\n");
-		return EXIT_FAILURE;
+		exit(EXIT_FAILURE);
 	}
 	if (argc > 2) {
 		printf("Error: too many command line arguments provided\n");
-		return EXIT_FAILURE;
+		exit(EXIT_FAILURE);
 	}
 
 


### PR DESCRIPTION
The output from `xxd` (which gets saved as `data.h`) produces a non null-terminated `char[]`. Specify the maximum length of the string in the call to `printf()`.

The alternative is to null-terminate the string in the declaration:
```C
const char text[] = {
#include "data.h"
, 0 // Add "null-character"
};
```